### PR TITLE
Edit compound install to use main branch

### DIFF
--- a/emulsify-drupal/emulsify-drupal/README.md
+++ b/emulsify-drupal/emulsify-drupal/README.md
@@ -13,7 +13,7 @@ description: >-
 1. [Node (we recommend NVM)](https://github.com/nvm-sh/nvm)
 2. [Emulsify CLI](https://docs.emulsify.info/supporting-projects/emulsify-cli) (Not strictly recommended, but all docs will assume its use)
 
-### Picking a version:
+### Picking a version
 
 * **4.x** - Drupal 9.x compatible
 * **2.x** - Drupal 8.x compatible (No longer supported)
@@ -26,7 +26,7 @@ Here's a [video walkthrough](https://modulesunraveled.wistia.com/medias/7cdtb3k4
 
 1. In your project root, initialize a theme based on the Drupal starter `emulsify init "My Awesome Theme"` (Using your preferred theme name)
 2. Move into your new theme `cd web/themes/custom/my_awesome_theme`
-3. Install the Compound system `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout 1.1.0`
+3. Install the Compound system `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout main`
 4. Build theme `npm run build`
 5. Enable your theme and its dependencies\* \*\*`drush then THEME_NAME -y && drush en components emulsify_twig -y`
 6. Set your custom theme as the default `drush config-set system.theme default THEME_NAME -y`
@@ -38,7 +38,7 @@ Here's a [video walkthrough](https://modulesunraveled.wistia.com/medias/7cdtb3k4
 ## Standalone (for prototyping outside of a Drupal install)
 
 1. Install the starter at your preferred location, and pass a starter\* (like Drupal) `emulsify init "My Awesome Theme" --platform drupal .` (The preceding snippet uses `.` to indicate "the current location")
-2. `cd` into that directory and install your system. `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout 1.1.0`&#x20;
+2. `cd` into that directory and install your system. `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout main`&#x20;
 3. Now you can run `npm run build` to simply compile things, or `npm run develop` to start working on the components in isolation.
 4. See [the FAQ](faq/) for the final step to avoid the `.git can't be found` error
 


### PR DESCRIPTION
**Summary**

This PR updates the Compound installation commands to use the `main` branch instead of a specific release version. This outdated information was flagged by @ccjjmartin in the [Emulsify Slack](https://emulsify.slack.com/archives/C4575Q30T/p1665089012757099).

**How to review this PR**
- [ ] Confirm that the new command works.