### PR TITLE
Update docs with some small changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Compound is the default Emulsify system, and currently includes a variant for Dr
 
 ### [Emulsify Cli](https://github.com/emulsify-ds/emulsify-cli)
 
-This is a command line interface for Emulsify. With it, you can initial a project, and identify a "system" (like Compound) for your project. Once initialized you can install individual components from that system into your project as "boiler-plate" code.
+This is a command line interface for Emulsify. With it, you can initialize a project, and identify a "system" (like Compound) for your project. Once initialized you can install individual components from that system into your project as "boiler-plate" code.
 
 ### Emulsify Twig
 

--- a/emulsify-drupal/emulsify-drupal/README.md
+++ b/emulsify-drupal/emulsify-drupal/README.md
@@ -26,7 +26,7 @@ Here's a [video walkthrough](https://modulesunraveled.wistia.com/medias/7cdtb3k4
 
 1. In your project root, initialize a theme based on the Drupal starter `emulsify init "My Awesome Theme"` (Using your preferred theme name)
 2. Move into your new theme `cd web/themes/custom/my_awesome_theme`
-3. Install the Compound system `emulsify system install --repository https://github.com/emulsify-ds/compound.git --checkout 1.1.0`
+3. Install the Compound system with the default components `emulsify system install compound`
 4. Build theme `npm run build`
 5. Enable your theme and its dependencies\* \*\*`drush then THEME_NAME -y && drush en components emulsify_twig -y`
 6. Set your custom theme as the default `drush config-set system.theme default THEME_NAME -y`

--- a/emulsify-drupal/emulsify-drupal/basic-usage/writing-stories.md
+++ b/emulsify-drupal/emulsify-drupal/basic-usage/writing-stories.md
@@ -2,7 +2,7 @@
 
 Writing components in Emulsify follows standard practices. You create your component Twig, .scss and/or .js files in component-specific directories.
 
-To show components in Storybook, however, you will need to create "stories." Storybook is very flexible and extensible, and there are addons that provide additional flexibility. We can't document everything you can do in Storybook, so below you'll find just a few examples of common ways to show your components in the Storybook UI.
+To show components in Storybook, however, you will need to create "stories." Storybook is very flexible and extensible, and there are addons that provide additional flexibility. We can't document everything you can do in Storybook, so below you'll find just a few examples of common ways to show your components in the Storybook UI. View more details on the [Storybook documentation site](https://storybook.js.org/docs/react/writing-stories/introduction).
 
 ### Simple annotated example
 


### PR DESCRIPTION
## Summary

Updates docs.

This PR fixes/implements the following **documentation changes**

- Typo of initial -> initialize
- Add link to Storybook writing stories for more details on that page
- Simplify the initial CLI usage for the default install - there already is documentation on more advanced usage - i.e. pulling form a specific repo.
 
As a newer use to Emulsify, I wanted the CLI to be more approachable. Also, it would be good to link to Storybook for more details on writing stories.

## How to review this pull request
- [ ] Verify the link to Storybook's writing stories page works
- [ ] Verify the CLI command is the correct one for a default install of Compound